### PR TITLE
Wrap status_code as a string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info < (3, 0):
 
 setuptools.setup(
     name='sprockets.mixins.statsd',
-    version='1.0.2',
+    version='1.0.3',
     description='Handler mixins for automated metric reporting',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.mixins.statsd.git',

--- a/sprockets/mixins/statsd/__init__.py
+++ b/sprockets/mixins/statsd/__init__.py
@@ -39,7 +39,7 @@ import os
 
 from sprockets.clients import statsd
 
-version_info = (1, 0, 2)
+version_info = (1, 0, 3)
 __version__ = '.'.join(str(v) for v in version_info)
 
 STATSD_PREFIX = os.getenv('STATSD_PREFIX', 'sprockets')
@@ -73,12 +73,12 @@ class RequestMetricsMixin(object):
                               self.__module__,
                               self.__class__.__name__,
                               self.request.method,
-                              self._status_code,
+                              str(self._status_code),
                               value=self.request.request_time() * 1000)
             statsd.incr(STATSD_PREFIX,
                         'counters',
                         self.__module__,
                         self.__class__.__name__,
                         self.request.method,
-                        self._status_code)
+                        str(self._status_code))
         super(RequestMetricsMixin, self).on_finish()

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,8 @@ class MixinTests(unittest.TestCase):
         self.duration = self.request._finish_time - self.request._start_time
         self.handler.on_finish()
         add_timing.assert_called_once_with('sprockets', 'timers', 'tests',
-                                           'StatsdRequestHandler', 'GET', 200,
+                                           'StatsdRequestHandler', 'GET',
+                                           '200',
                                            value=self.duration * 1000)
 
     @mock.patch('sprockets.clients.statsd.add_timing')
@@ -57,4 +58,4 @@ class MixinTests(unittest.TestCase):
     def test_on_finish_calls_statsd_incr(self, incr, add_timing):
         self.handler.on_finish()
         incr.assert_called_once_with('sprockets', 'counters', 'tests',
-                                     'StatsdRequestHandler', 'GET', 200)
+                                     'StatsdRequestHandler', 'GET', '200')


### PR DESCRIPTION
Causes a TypeError since status code is part of the list that is being joined to construct the key
