### PR TITLE
Add hostname to the metric path

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,9 +1,22 @@
 Version History
 ---------------
-- 1.0.4 [2014-08-29]
- - Status code bug fixes
- - Version string interpolation fixes
- - Move the global STATSD_PREFIX to a class attribute to allow modifications
 
-- 1.0.0 [2014-08-29]
- - Initial version
+`1.1.0`_ (2015-03-19)
+=====================
+
+ * Insert the hostname into the metric path
+
+`1.0.4`_ (2014-08-29)
+=====================
+ * Status code bug fixes
+ * Version string interpolation fixes
+ * Move the global STATSD_PREFIX to a class attribute to allow modifications
+
+`1.0.0`_ (2014-08-29)
+=====================
+ * Initial version
+
+
+.. _1.1.0: https://github-enterprise.colo.lair/aweber/communicator/compare/1.0.4...1.1.0
+.. _1.0.4: https://github-enterprise.colo.lair/aweber/communicator/compare/1.0.0...1.0.4
+.. _1.0.0: https://github-enterprise.colo.lair/aweber/communicator/compare/0.0.0...1.0.0

--- a/sprockets/mixins/statsd/__init__.py
+++ b/sprockets/mixins/statsd/__init__.py
@@ -36,10 +36,11 @@ Each request will send metrics ``on_finish`` in the following format:
 
 """
 import os
+import socket
 
 from sprockets.clients import statsd
 
-version_info = (1, 0, 4)
+version_info = (1, 1, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 
@@ -76,20 +77,21 @@ class RequestMetricsMixin(object):
 
         .. code::
 
-            <STATSD_PREFIX>.counters.package[.module].Class.METHOD.STATUS
-            sprockets.counters.tornado.web.RequestHandler.GET.200
+            <PREFIX>.counters.<host>.package[.module].Class.METHOD.STATUS
+            sprockets.counters.localhost.tornado.web.RequestHandler.GET.200
 
         Adds a value to a timer in the following format:
 
         .. code::
 
-            <STATSD_PREFIX>.timers.package[.module].Class.METHOD.STATUS
-            sprockets.timers.tornado.web.RequestHandler.GET.200
+            <PREFIX>.timers.<host>.package[.module].Class.METHOD.STATUS
+            sprockets.timers.localhost.tornado.web.RequestHandler.GET.200
 
         """
         if hasattr(self, 'request') and self.request:
             statsd.add_timing(self.statsd_prefix,
                               'timers',
+                              socket.gethostname(),
                               self.__module__,
                               self.__class__.__name__,
                               self.request.method,
@@ -98,6 +100,7 @@ class RequestMetricsMixin(object):
 
             statsd.incr(self.statsd_prefix,
                         'counters',
+                        socket.gethostname(),
                         self.__module__,
                         self.__class__.__name__,
                         self.request.method,

--- a/tests.py
+++ b/tests.py
@@ -42,20 +42,22 @@ class MixinTests(unittest.TestCase):
         self.handler = StatsdRequestHandler(self.application, self.request)
         self.handler._status_code = 200
 
+    @mock.patch('sprockets.mixins.statsd.socket')
     @mock.patch('sprockets.clients.statsd.add_timing')
     @mock.patch('sprockets.clients.statsd.incr')
-    def test_on_finish_calls_statsd_add_timing(self, incr, add_timing):
+    def test_on_finish_calls_statsd_add_timing(self, incr, add_timing, socket):
         self.request._finish_time = self.request._start_time + 1
         self.duration = self.request._finish_time - self.request._start_time
         self.handler.on_finish()
-        add_timing.assert_called_once_with('sprockets', 'timers', 'tests',
-                                           'StatsdRequestHandler', 'GET',
-                                           '200',
-                                           value=self.duration * 1000)
+        add_timing.assert_called_once_with(
+            'sprockets', 'timers', socket.gethostname.return_value, 'tests',
+            'StatsdRequestHandler', 'GET', '200', value=self.duration * 1000)
 
+    @mock.patch('sprockets.mixins.statsd.socket')
     @mock.patch('sprockets.clients.statsd.add_timing')
     @mock.patch('sprockets.clients.statsd.incr')
-    def test_on_finish_calls_statsd_incr(self, incr, add_timing):
+    def test_on_finish_calls_statsd_incr(self, incr, add_timing, socket):
         self.handler.on_finish()
-        incr.assert_called_once_with('sprockets', 'counters', 'tests',
-                                     'StatsdRequestHandler', 'GET', '200')
+        incr.assert_called_once_with(
+            'sprockets', 'counters', socket.gethostname.return_value,
+            'tests', 'StatsdRequestHandler', 'GET', '200')


### PR DESCRIPTION
This PR adds the name of the host emitting the metric so we can look at metrics from a particular host.  Additionally we won't run into the issue where graphite gets the same metric from many sources and decides to ignore all but the first.  Because that sucks.