### PR TITLE
Allow the hostname to be optionally included

### DIFF
--- a/sprockets/mixins/statsd/__init__.py
+++ b/sprockets/mixins/statsd/__init__.py
@@ -106,8 +106,8 @@ class RequestMetricsMixin(object):
 
         if hasattr(self, 'request') and self.request:
             if self.statsd_use_hostname:
-                timer_prefix = 'timers.{}'.format(socket.gethostname())
-                counter_prefix = 'counters.{}'.format(socket.gethostname())
+                timer_prefix = 'timers.{0}'.format(socket.gethostname())
+                counter_prefix = 'counters.{0}'.format(socket.gethostname())
             else:
                 timer_prefix = 'timers'
                 counter_prefix = 'counters'

--- a/tests.py
+++ b/tests.py
@@ -45,19 +45,37 @@ class MixinTests(unittest.TestCase):
         self.handler._status_code = 200
 
     def test_on_finish_calls_statsd_add_timing(self):
+        self.handler.statsd_use_hostname = True
         self.request._finish_time = self.request._start_time + 1
         self.duration = self.request._finish_time - self.request._start_time
         with mock.patch('sprockets.clients.statsd.add_timing') as add_timing:
             self.handler.on_finish()
-            add_timing.assert_called_once_with('timers', socket.gethostname(),
-                                               'tests', 'StatsdRequestHandler',
-                                               'GET', '200',
-                                                value=self.duration * 1000)
+            add_timing.assert_called_once_with(
+                'timers.' + socket.gethostname(), 'tests',
+                'StatsdRequestHandler', 'GET', '200',
+                value=self.duration * 1000)
 
     def test_on_finish_calls_statsd_incr(self):
+        self.handler.statsd_use_hostname = True
         with mock.patch('sprockets.clients.statsd.incr') as incr:
             self.handler.on_finish()
-            incr.assert_called_once_with('counters',
-                                         socket.gethostname(),
-                                         'tests', 'StatsdRequestHandler',
-                                         'GET', '200')
+            incr.assert_called_once_with(
+                'counters.' + socket.gethostname(), 'tests',
+                'StatsdRequestHandler', 'GET', '200')
+
+    def test_on_finish_calls_statsd_add_timing_without_hostname(self):
+        self.handler.statsd_use_hostname = False
+        self.request._finish_time = self.request._start_time + 1
+        self.duration = self.request._finish_time - self.request._start_time
+        with mock.patch('sprockets.clients.statsd.add_timing') as add_timing:
+            self.handler.on_finish()
+            add_timing.assert_called_once_with(
+                'timers', 'tests', 'StatsdRequestHandler', 'GET', '200',
+                value=self.duration * 1000)
+
+    def test_on_finish_calls_statsd_incr_without_hostname(self):
+        self.handler.statsd_use_hostname = False
+        with mock.patch('sprockets.clients.statsd.incr') as incr:
+            self.handler.on_finish()
+            incr.assert_called_once_with(
+                'counters', 'tests', 'StatsdRequestHandler', 'GET', '200')


### PR DESCRIPTION
This will let us set an environment variable (or class level attribute) for our services that use Docker and DataDog to omit the hostname in the metric path.